### PR TITLE
Authentication getestet

### DIFF
--- a/P5/Exemplars/Makefile
+++ b/P5/Exemplars/Makefile
@@ -45,6 +45,16 @@ ANT=ANT_OPTS="-Xss2m -Xmx752m -Djava.awt.headless=true" ant -lib ../Utilities/li
 
 default: schemas
 
+# Note on construction of this file:
+#   For every target that does stuff the target starts by echoing a
+#   blank line and a notification line about which target is being
+#   run. The “$@” variable is used, which writes out the file name of
+#   the target. If the target name contains a ‘%’ (and thus gets run
+#   over multiple matching files) the message says “target file”
+#   instead of just “target”. Thus the user sees the actual file being
+#   worked on, and can figure out the target from that name.
+# —Syd, 2025-09-21 (copied from 2021-08-20 msg in P5/Test/Makefile.)
+
 schemas: $(NORMALODDS) $(ODDSJUSTRELAX) $(SPECIALODDS) $(ADDITIONALXSDS) $(ODDSJRNCID)
 	echo Done
 
@@ -52,6 +62,8 @@ docschemas: $(DOCODDS) $(DOCONLYODDS)
 	echo Done schemas which needed doc
 
 %.special: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	xmllint --xinclude $*.odd > $*.odd.xinclude
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dtestfile2=$*.template -Dtestfile=$*.tei -DoddFile=$*.odd.xinclude validateodd compileodd rng validaterng validatesecondrng isoschematron validateschematron exampleschema cleanup
 	../run-onvdl $*.nvdl $*.odd.xinclude
@@ -59,16 +71,22 @@ docschemas: $(DOCODDS) $(DOCONLYODDS)
 	${TRANG} $*.rng $*.rnc
 
 %.rng: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	@echo debug: run lots of stuff via Test/antruntest, normal
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dtestfile=$*.tei -DoddFile=$*.odd validateodd compileodd dtd rng validaterng  isoschematron validateschematron cleanup
 	${TRANG}  $*.rng $*.rnc
 
 tei_customization.rng: tei_customization.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target $@ ---------"
 	@echo debug: run lots of stuff via Test/antruntest, DTDcompat=false
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=tei_customization -Dtestfile=tei_customization.tei -DoddFile=tei_customization.odd -DDTDcompat=false validateodd compileodd dtd rng validaterng  isoschematron validateschematron cleanup
 	${TRANG} tei_customization.rng tei_customization.rnc
 
 %.dtd: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dtestfile=$*.tei -DoddFile=$*.odd validateodd compileodd rng dtd exampleschema isoschematron validateschematron cleanup
 	../run-onvdl $*.nvdl $*.odd
 	${TRANG}  $*.rng $*.rnc
@@ -85,15 +103,21 @@ tei_customization.rng: tei_customization.odd
 	xmllint --noout --dtdvalid $*.dtd $*.tei
 
 %.doc.pdf: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dtestfile=$*.tei -DoddFile=$*.odd validateodd compileodd docepub docpdf dochtml cleanup
 
 %.doc.epub: %.odd
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	$(ANT) -f ../Test/antruntest.xml -Doutputname=$* -Dlang=`echo $* | sed 's/.*_//'` -Dtestfile=$*.tei -DoddFile=$*.odd validateodd compileodd rng docepub docpdf dochtml exampleschema cleanup
 	../run-onvdl $*.nvdl $*.odd
 	-rm $*.doc.xml
 	-rm $*.rng
 
 %.xsd: %.rng
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target file $@ ---------"
 	${TRANG}   -o disable-abstract-elements $*.rng $*.xsd
 	-test -f xml.xsd && mv xml.xsd $*_xml.xsd                && perl -p -i -e "s+teix.xsd+$*_teix.xsd+;s+ns1.xsd+$*_ns1.xsd+" $*_xml.xsd && perl -p -i -e "s+xml.xsd+$*_xml.xsd+" $*.xsd
 	-test -f teix.xsd && mv teix.xsd $*_teix.xsd && perl -p -i -e "s+xml.xsd+$*_xml.xsd+;s+ns1.xsd+$*_ns1.xsd+" $*_teix.xsd      && perl -p -i -e "s/teix.xsd/$*_teix.xsd/" $*.xsd
@@ -107,11 +131,15 @@ tei_customization.rng: tei_customization.odd
 tei_customization.odd: ../Utilities/TEI-to-tei_customization.xslt ../p5subset.xml
 #	Note that the "../p5subset.xml" in above line is the same as the definition
 #	of ${SOURCE}, but you can't use a variable as prerequisite (at least, it
-#	didn't work for me. :-)  Syd, 2017-11-05
+#	didn't work for me. :-)  — Syd, 2017-11-05
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target $@ ---------"
 	@echo generating tei_customization.odd from p5subset
 	$(SAXON) -s:${SOURCE} -xsl:../Utilities/TEI-to-tei_customization.xslt -o:tei_customization.odd
 
 dist: schemas docschemas
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target $@ ---------"
 	rm -rf tei[0-9]*.xml ../release/tei-p5-exemplars
 	rm -f *-teix*
 	rm -f *compiled* *.doc.tex
@@ -140,6 +168,8 @@ dist: schemas docschemas
 	cp ../catalog.p5.custom ../release/tei-p5-exemplars/share/xml/tei/custom/schema/catalog.xml
 
 clean:
+	@echo " "
+	@echo "--------- P5/Exemplars/Makefile work on target $@ ---------"
 	mv tei_lite_fr.nvdl tei_lite_fr.nvdl.bak
 	rm -f *.processed *.xsd *.dtd *.doc.* *.rnc tei*.xsl tei*.rng *.compiled* *~ *.xi *.isosch *.epub *.pdf *.html *.nvdl *-teix*
 	mv tei_lite_fr.nvdl.bak tei_lite_fr.nvdl

--- a/P5/Makefile
+++ b/P5/Makefile
@@ -33,10 +33,13 @@ sinclude local.mk
 default: validate exemplars test html-web
 
 convert: schemas
+	@echo "--------- P5/Makefile target=$@"
 
 check: check.stamp  p5.xml
+	@echo "--------- P5/Makefile target=$@"
 
 check.stamp:
+	@echo "--------- P5/Makefile target=$@"
 	@echo Checking you have running XML tools and Perl before trying to run transform...
 	@echo -n Ant:
 	@command -v  ant || exit 1
@@ -49,8 +52,9 @@ check.stamp:
 	touch check.stamp
 
 p5.xml: ${DRIVER} Source/Specs/*.xml Source/Guidelines/en/*.xml p5odds.odd check.stamp
-	@echo get latest date:
-	@echo VCS is ${VCS}
+	@echo "--------- P5/Makefile target=$@"
+	@echo "Creating an XML file with the date last updated and commit number garnered from the VCS system (${VCS}),"
+	@echo "if available. (This XML file, repodate.xml, will be inserted into the <editionStmt> of the Guidelines)"
 	case ${VCS} in \
 	   svn) if [ ${INJENKINS} = "true" ] ; \
 	           then svn info --xml svn://svn.code.sf.net/p/tei/code/trunk/P5 ; \
@@ -69,11 +73,16 @@ p5.xml: ${DRIVER} Source/Specs/*.xml Source/Guidelines/en/*.xml p5odds.odd check
 	touch schemas.stamp
 
 schemas: schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
+
 schemas.stamp: p5.xml
+	@echo "--------- P5/Makefile target=$@"
 
 html-web: check.stamp p5.xml  html-web.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 html-web.stamp:  check.stamp p5.xml  Utilities/guidelines.xsl.model
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making HTML Guidelines for language ${INPUTLANGUAGE}
 	@# remove vestiges of previous run
 	rm -rf Guidelines-web
@@ -101,6 +110,7 @@ html-web.stamp:  check.stamp p5.xml  Utilities/guidelines.xsl.model
 	touch html-web.stamp
 
 teiwebsiteguidelines:
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: make HTML version of Guidelines just for TEI web site
 	rm -rf teiwebsiteguidelines.zip
 	rm -f html-web.stamp
@@ -110,16 +120,19 @@ teiwebsiteguidelines:
 epub: Guidelines.epub
 
 Guidelines.epub: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make epub version of Guidelines
 	${ANT} -f ${XSL}/epub3/build-to.xml -lib Utilities/lib/${SAXONJAR} -Dprofiledir=${XSL}/profiles -Dprofile=tei -DinputFile=`pwd`/p5.xml -DoutputFile=`pwd`/Guidelines.epub -Dcoverimage=`pwd`/Utilities/cover.jpg
 	java -jar Utilities/epubcheck3.jar Guidelines.epub
 	touch Guidelines.epub
 
 epub3: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	${ANT}  -f ${XSL}/epub3/build-to.xml -lib Utilities/lib/${SAXONJAR} -Dprofiledir=${XSL}/profiles -Dprofile=tei -DinputFile=`pwd`/p5.xml -DoutputFile=`pwd`/Guidelines.epub -Dcoverimage=`pwd`/Utilities/cover.jpg
 	java -jar Utilities/epubcheck3.jar Guidelines.epub
 
 fonttest:
+	@echo "--------- P5/Makefile target=$@"
 	-xelatex --interaction=batchmode Utilities/fonttest
 	if [ -f "missfont.log" ]  ; then  \
 	  perl -p -i -e 's/(.*Minion)/%\1/;s/(.*Myriad)/%\1/' Utilities/guidelines.xsl ;\
@@ -130,6 +143,7 @@ fonttest:
 	rm -f fonttest.*
 
 pdf-init: check.stamp p5.xml Utilities/guidelines-latex.xsl
+	@echo "--------- P5/Makefile target=$@"
 	@echo check if XeLaTeX exist
 	@command -v xelatex || exit 1
 	java -jar Utilities/lib/${SAXONJAR} -s:Utilities/guidelines-latex.xsl -xsl:Utilities/guidelines_model_2_executable.xslt -o:Utilities/guidelines.xsl XSL="${XSL}"
@@ -138,11 +152,13 @@ pdf-init: check.stamp p5.xml Utilities/guidelines-latex.xsl
 	${ANT} -lib Utilities/lib/${SAXONJAR} -f antbuilder.xml -DXSL=${XSL} -DXELATEX=${XELATEX} pdfonce
 
 pdf: pdf-init
+	@echo "--------- P5/Makefile target=$@"
 	${ANT} -lib Utilities/lib/${SAXONJAR} -f antbuilder.xml -DXSL=${XSL} -DXELATEX=${XELATEX} pdfrest 2> pdfbuild.log 1> pdfbuild.log
 	grep -v "Failed to convert input string to UTF16" pdfbuild.log
 	for auxFile in Guidelines*aux; do perl -p -i -e 's/.*zf@fam.*//' $$auxFile; done
 
 rewraprnc:
+	@echo "--------- P5/Makefile target=$@"
 	for i in Guidelines-REF*tex; \
 	  do \
 	     perl Utilities/rewrapRNC-in-TeX.pl <$$i>$$i.new; \
@@ -152,6 +168,7 @@ rewraprnc:
 	done
 
 chapterpdfs: check
+	@echo "--------- P5/Makefile target=$@"
 	for i in `grep "\\include{" Guidelines.tex | sed 's/.*{\(.*\)}.*/\\1/'`; \
 	do echo PDF for chapter $$i; \
 	echo  $$i | ${XELATEX} Guidelines; \
@@ -161,9 +178,11 @@ chapterpdfs: check
 	done
 
 validate: schemas.stamp valid
+	@echo "--------- P5/Makefile target=$@"
 
 valid: jing_version=$(wordlist 1,3,$(shell jing))
 valid: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Check validity with rnv \(https://github.com/dtolpin/RNV\) if we have it
 	-command -v  rnv && rnv -v p5odds.rnc p5.xml
 	@echo BUILD: Check validity with special-purpose XSL code, looking for bad links etc
@@ -176,14 +195,17 @@ valid: check.stamp p5.xml
 	./run-onvdl p5valid.nvdl v.xml
 
 test: schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD Run test cases for P5
 	(cd Test; make XSL=${XSL} VCS=${VCS})
 
 exemplars:  schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD TEI Exemplars
 	(cd Exemplars; make XSL=${XSL} PREFIX=${PREFIX} VCS=${VCS})
 
 dist-source.stamp: check.stamp p5.xml  schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for source
 	rm -rf release/tei-p5-source*
 	mkdir -p release/tei-p5-source/share/xml/tei/odd
@@ -231,6 +253,7 @@ dist-source.stamp: check.stamp p5.xml  schemas.stamp
 	rm p5subset*.json p5attlist.txt stripspace.xsl.model
 
 dist-schema.stamp:check.stamp p5.xml schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for schema
 	rm -rf release/tei-p5-schema*
 	mkdir -p release/tei-p5-schema/share/xml/tei/schema/dtd
@@ -243,6 +266,7 @@ dist-schema.stamp:check.stamp p5.xml schemas.stamp
 	touch dist-schema.stamp
 
 readus:
+	@echo "--------- P5/Makefile target=$@"
 	@echo Make just the README files for testing purposes only
 	@echo BUILD: Make distribution directory for doc
 	rm -rf release/tei-p5-doc*
@@ -255,6 +279,7 @@ readus:
 	done
 
 dist-doc.stamp:  check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for doc
 	rm -rf release/tei-p5-doc*
 	mkdir -p release/tei-p5-doc/share/doc/tei-p5-doc/en
@@ -275,6 +300,7 @@ dist-doc.stamp:  check.stamp p5.xml
 	touch dist-doc.stamp
 
 dist-test.stamp: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for test
 	rm -rf release/tei-p5-test*
 	mkdir -p release/tei-p5-test/share/xml/tei
@@ -284,6 +310,7 @@ dist-test.stamp: check.stamp p5.xml
 	touch dist-test.stamp
 
 dist-exemplars.stamp: check.stamp p5.xml  schemas.stamp
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for exemplars
 	(cd Exemplars; make XSL=${XSL} dist)
 	tar --exclude "*~" --exclude .svn -c -f - Exemplars \
@@ -291,6 +318,7 @@ dist-exemplars.stamp: check.stamp p5.xml  schemas.stamp
 	touch dist-exemplars.stamp
 
 dist-database.stamp: check.stamp p5.xml
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make distribution directory for database
 	rm -rf release/tei-p5-database*
 	mkdir -p release/tei-p5-database/share/xml/tei/xquery
@@ -299,18 +327,25 @@ dist-database.stamp: check.stamp p5.xml
 	touch dist-database.stamp
 
 dist-source: dist-source.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-schema: dist-schema.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-doc: dist-doc.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-test: dist-test.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-exemplars: dist-exemplars.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist-database: dist-database.stamp
+	@echo "--------- P5/Makefile target=$@"
 
 dist: dist-source dist-schema dist-doc dist-test dist-exemplars dist-database
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make overall zip archive
 	rm -rf tei-*.zip release/xml release/doc
 	(cd release/tei-p5-database/share; tar cf - . | (cd ../../; tar xf - ))
@@ -330,6 +365,7 @@ dist: dist-source dist-schema dist-doc dist-test dist-exemplars dist-database
 	(cd release; zip -q -r tei-p5-test-${UPVERSION}.zip tei-p5-test )
 
 debversion:
+	@echo "--------- P5/Makefile target=$@"
 	sh ./mydch debian-tei-p5-database/debian/changelog
 	sh ./mydch debian-tei-p5-doc/debian/changelog
 	sh ./mydch debian-tei-p5-exemplars/debian/changelog
@@ -338,6 +374,7 @@ debversion:
 	sh ./mydch debian-tei-p5-test/debian/changelog
 
 deb: debversion
+	@echo "--------- P5/Makefile target=$@"
 	rm -f tei-p5-*_*deb
 	rm -f tei-p5-*_*changes
 	rm -f tei-p5-*_*build
@@ -355,32 +392,40 @@ deb: debversion
 	(cd debian-tei-p5-test; debclean;debuild -eXSL=${XSL} -eVCS=${VCS} -eINJENKINS=${INJENKINS} --no-lintian  -nc  -b  -i.svn -I.svn -uc -us)
 
 install-schema: dist-schema
+	@echo "--------- P5/Makefile target=$@"
 	@echo Making schema release in ${PREFIX}
 	(cd release/tei-p5-schema; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-doc: dist-doc
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Make doc release in ${PREFIX}
 	(cd release/tei-p5-doc; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-source: dist-source
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making source release in ${PREFIX}
 	(cd release/tei-p5-source; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-test: dist-test
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making testfiles release in ${PREFIX}
 	(cd release/tei-p5-test; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-exemplars: dist-exemplars
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making exemplars release in ${PREFIX}
 	(cd release/tei-p5-exemplars; tar cf - share) | (cd ${PREFIX}; tar xf -)
 
 install-database: dist-database
+	@echo "--------- P5/Makefile target=$@"
 	@echo BUILD: Making database release in ${PREFIX}
 	(cd release/tei-p5-database; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install: clean install-schema install-doc install-test install-exemplars install-source install-database
+	@echo "--------- P5/Makefile target=$@"
 
 dependencies:
+	@echo "--------- P5/Makefile target=$@"
 	@echo to make this thing build under Ubuntu/Debian, here are all the packages you will need:
 	@echo	msttcorefonts
 	@echo	rnv
@@ -389,7 +434,9 @@ dependencies:
 	@echo	zip
 	@echo   ttf-linux-libertine
 	@echo 	fonts-noto-cjk
+
 clean:
+	@echo "--------- P5/Makefile target=$@"
 	(cd Exemplars; make clean)
 	(cd Test; make clean)
 	rm -f repodate.xml

--- a/P5/Makefile
+++ b/P5/Makefile
@@ -32,14 +32,27 @@ sinclude local.mk
 
 default: validate exemplars test html-web
 
+# Note on construction of this file:
+#   For every target that does stuff the target starts by echoing a
+#   blank line and a notification line about which target is being
+#   run. The “$@” variable is used, which writes out the file name of
+#   the target. If the target name contains a ‘%’ (and thus gets run
+#   over multiple matching files) the message says “target file”
+#   instead of just “target”. Thus the user sees the actual file being
+#   worked on, and can figure out the target from that name.
+# —Syd, 2025-09-21 (copied from 2021-08-20 msg in P5/Test/Makefile.)
+
 convert: schemas
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 check: check.stamp  p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 check.stamp:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo Checking you have running XML tools and Perl before trying to run transform...
 	@echo -n Ant:
 	@command -v  ant || exit 1
@@ -52,7 +65,8 @@ check.stamp:
 	touch check.stamp
 
 p5.xml: ${DRIVER} Source/Specs/*.xml Source/Guidelines/en/*.xml p5odds.odd check.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo "Creating an XML file with the date last updated and commit number garnered from the VCS system (${VCS}),"
 	@echo "if available. (This XML file, repodate.xml, will be inserted into the <editionStmt> of the Guidelines)"
 	case ${VCS} in \
@@ -73,16 +87,20 @@ p5.xml: ${DRIVER} Source/Specs/*.xml Source/Guidelines/en/*.xml p5odds.odd check
 	touch schemas.stamp
 
 schemas: schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 schemas.stamp: p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 html-web: check.stamp p5.xml  html-web.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 html-web.stamp:  check.stamp p5.xml  Utilities/guidelines.xsl.model
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making HTML Guidelines for language ${INPUTLANGUAGE}
 	@# remove vestiges of previous run
 	rm -rf Guidelines-web
@@ -110,7 +128,8 @@ html-web.stamp:  check.stamp p5.xml  Utilities/guidelines.xsl.model
 	touch html-web.stamp
 
 teiwebsiteguidelines:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: make HTML version of Guidelines just for TEI web site
 	rm -rf teiwebsiteguidelines.zip
 	rm -f html-web.stamp
@@ -120,19 +139,22 @@ teiwebsiteguidelines:
 epub: Guidelines.epub
 
 Guidelines.epub: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make epub version of Guidelines
 	${ANT} -f ${XSL}/epub3/build-to.xml -lib Utilities/lib/${SAXONJAR} -Dprofiledir=${XSL}/profiles -Dprofile=tei -DinputFile=`pwd`/p5.xml -DoutputFile=`pwd`/Guidelines.epub -Dcoverimage=`pwd`/Utilities/cover.jpg
 	java -jar Utilities/epubcheck3.jar Guidelines.epub
 	touch Guidelines.epub
 
 epub3: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	${ANT}  -f ${XSL}/epub3/build-to.xml -lib Utilities/lib/${SAXONJAR} -Dprofiledir=${XSL}/profiles -Dprofile=tei -DinputFile=`pwd`/p5.xml -DoutputFile=`pwd`/Guidelines.epub -Dcoverimage=`pwd`/Utilities/cover.jpg
 	java -jar Utilities/epubcheck3.jar Guidelines.epub
 
 fonttest:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	-xelatex --interaction=batchmode Utilities/fonttest
 	if [ -f "missfont.log" ]  ; then  \
 	  perl -p -i -e 's/(.*Minion)/%\1/;s/(.*Myriad)/%\1/' Utilities/guidelines.xsl ;\
@@ -143,7 +165,8 @@ fonttest:
 	rm -f fonttest.*
 
 pdf-init: check.stamp p5.xml Utilities/guidelines-latex.xsl
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo check if XeLaTeX exist
 	@command -v xelatex || exit 1
 	java -jar Utilities/lib/${SAXONJAR} -s:Utilities/guidelines-latex.xsl -xsl:Utilities/guidelines_model_2_executable.xslt -o:Utilities/guidelines.xsl XSL="${XSL}"
@@ -152,13 +175,15 @@ pdf-init: check.stamp p5.xml Utilities/guidelines-latex.xsl
 	${ANT} -lib Utilities/lib/${SAXONJAR} -f antbuilder.xml -DXSL=${XSL} -DXELATEX=${XELATEX} pdfonce
 
 pdf: pdf-init
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	${ANT} -lib Utilities/lib/${SAXONJAR} -f antbuilder.xml -DXSL=${XSL} -DXELATEX=${XELATEX} pdfrest 2> pdfbuild.log 1> pdfbuild.log
 	grep -v "Failed to convert input string to UTF16" pdfbuild.log
 	for auxFile in Guidelines*aux; do perl -p -i -e 's/.*zf@fam.*//' $$auxFile; done
 
 rewraprnc:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	for i in Guidelines-REF*tex; \
 	  do \
 	     perl Utilities/rewrapRNC-in-TeX.pl <$$i>$$i.new; \
@@ -168,7 +193,8 @@ rewraprnc:
 	done
 
 chapterpdfs: check
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	for i in `grep "\\include{" Guidelines.tex | sed 's/.*{\(.*\)}.*/\\1/'`; \
 	do echo PDF for chapter $$i; \
 	echo  $$i | ${XELATEX} Guidelines; \
@@ -178,11 +204,13 @@ chapterpdfs: check
 	done
 
 validate: schemas.stamp valid
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 valid: jing_version=$(wordlist 1,3,$(shell jing))
 valid: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Check validity with rnv \(https://github.com/dtolpin/RNV\) if we have it
 	-command -v  rnv && rnv -v p5odds.rnc p5.xml
 	@echo BUILD: Check validity with special-purpose XSL code, looking for bad links etc
@@ -195,17 +223,20 @@ valid: check.stamp p5.xml
 	./run-onvdl p5valid.nvdl v.xml
 
 test: schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD Run test cases for P5
 	(cd Test; make XSL=${XSL} VCS=${VCS})
 
 exemplars:  schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD TEI Exemplars
 	(cd Exemplars; make XSL=${XSL} PREFIX=${PREFIX} VCS=${VCS})
 
 dist-source.stamp: check.stamp p5.xml  schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for source
 	rm -rf release/tei-p5-source*
 	mkdir -p release/tei-p5-source/share/xml/tei/odd
@@ -253,7 +284,8 @@ dist-source.stamp: check.stamp p5.xml  schemas.stamp
 	rm p5subset*.json p5attlist.txt stripspace.xsl.model
 
 dist-schema.stamp:check.stamp p5.xml schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for schema
 	rm -rf release/tei-p5-schema*
 	mkdir -p release/tei-p5-schema/share/xml/tei/schema/dtd
@@ -266,7 +298,8 @@ dist-schema.stamp:check.stamp p5.xml schemas.stamp
 	touch dist-schema.stamp
 
 readus:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo Make just the README files for testing purposes only
 	@echo BUILD: Make distribution directory for doc
 	rm -rf release/tei-p5-doc*
@@ -279,7 +312,8 @@ readus:
 	done
 
 dist-doc.stamp:  check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for doc
 	rm -rf release/tei-p5-doc*
 	mkdir -p release/tei-p5-doc/share/doc/tei-p5-doc/en
@@ -300,7 +334,8 @@ dist-doc.stamp:  check.stamp p5.xml
 	touch dist-doc.stamp
 
 dist-test.stamp: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for test
 	rm -rf release/tei-p5-test*
 	mkdir -p release/tei-p5-test/share/xml/tei
@@ -310,7 +345,8 @@ dist-test.stamp: check.stamp p5.xml
 	touch dist-test.stamp
 
 dist-exemplars.stamp: check.stamp p5.xml  schemas.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for exemplars
 	(cd Exemplars; make XSL=${XSL} dist)
 	tar --exclude "*~" --exclude .svn -c -f - Exemplars \
@@ -318,7 +354,8 @@ dist-exemplars.stamp: check.stamp p5.xml  schemas.stamp
 	touch dist-exemplars.stamp
 
 dist-database.stamp: check.stamp p5.xml
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make distribution directory for database
 	rm -rf release/tei-p5-database*
 	mkdir -p release/tei-p5-database/share/xml/tei/xquery
@@ -327,25 +364,32 @@ dist-database.stamp: check.stamp p5.xml
 	touch dist-database.stamp
 
 dist-source: dist-source.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-schema: dist-schema.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-doc: dist-doc.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-test: dist-test.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-exemplars: dist-exemplars.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist-database: dist-database.stamp
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dist: dist-source dist-schema dist-doc dist-test dist-exemplars dist-database
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make overall zip archive
 	rm -rf tei-*.zip release/xml release/doc
 	(cd release/tei-p5-database/share; tar cf - . | (cd ../../; tar xf - ))
@@ -365,7 +409,8 @@ dist: dist-source dist-schema dist-doc dist-test dist-exemplars dist-database
 	(cd release; zip -q -r tei-p5-test-${UPVERSION}.zip tei-p5-test )
 
 debversion:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	sh ./mydch debian-tei-p5-database/debian/changelog
 	sh ./mydch debian-tei-p5-doc/debian/changelog
 	sh ./mydch debian-tei-p5-exemplars/debian/changelog
@@ -374,7 +419,8 @@ debversion:
 	sh ./mydch debian-tei-p5-test/debian/changelog
 
 deb: debversion
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	rm -f tei-p5-*_*deb
 	rm -f tei-p5-*_*changes
 	rm -f tei-p5-*_*build
@@ -392,40 +438,48 @@ deb: debversion
 	(cd debian-tei-p5-test; debclean;debuild -eXSL=${XSL} -eVCS=${VCS} -eINJENKINS=${INJENKINS} --no-lintian  -nc  -b  -i.svn -I.svn -uc -us)
 
 install-schema: dist-schema
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo Making schema release in ${PREFIX}
 	(cd release/tei-p5-schema; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-doc: dist-doc
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Make doc release in ${PREFIX}
 	(cd release/tei-p5-doc; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-source: dist-source
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making source release in ${PREFIX}
 	(cd release/tei-p5-source; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-test: dist-test
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making testfiles release in ${PREFIX}
 	(cd release/tei-p5-test; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install-exemplars: dist-exemplars
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making exemplars release in ${PREFIX}
 	(cd release/tei-p5-exemplars; tar cf - share) | (cd ${PREFIX}; tar xf -)
 
 install-database: dist-database
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo BUILD: Making database release in ${PREFIX}
 	(cd release/tei-p5-database; tar cf - .) | (cd ${PREFIX}; tar xf - )
 
 install: clean install-schema install-doc install-test install-exemplars install-source install-database
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 
 dependencies:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	@echo to make this thing build under Ubuntu/Debian, here are all the packages you will need:
 	@echo	msttcorefonts
 	@echo	rnv
@@ -436,7 +490,8 @@ dependencies:
 	@echo 	fonts-noto-cjk
 
 clean:
-	@echo "--------- P5/Makefile target=$@"
+	@echo " "
+	@echo "--------- P5/Makefile work on target $@ ---------"
 	(cd Exemplars; make clean)
 	(cd Test; make clean)
 	rm -f repodate.xml

--- a/P5/Source/Guidelines/en/HD-Header.xml
+++ b/P5/Source/Guidelines/en/HD-Header.xml
@@ -669,6 +669,83 @@ Note here the use of the <att>target</att> attribute to point to a location from
 <specGrp xml:id="D2224" n="The publication statement"><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/publicationStmt.xml"/><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/distributor.xml"/><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/authority.xml"/><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/idno.xml"/><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/availability.xml"/><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/licence.xml"/>
 </specGrp>
 </div>
+  
+
+  <div type="div3" xml:id="HD25">
+    <head>The Authentication Statement</head>
+    <p>Texts can create social reality. Humans have developed several methods to warrant that they gain trust. These methods for procedural and symoblic authentication include signatures, seals or stamps committing the person represented by this to claim made by the text. This chapter introduces the <gi>authenticationStmt</gi> to describe this. The user of this element can include simple prose or use three elements to be more explicit. Birth certificates, ionternational treaties, commercial contracts, land leases, royal diplomas, or imperial decress are concrete examples of this. They gain authority through the trust that text corresponds to the reality. Societies have developed mechanisms of validation that support this trust, reducing the risk of being dismissed as forgeries or drafts. These authentication methods can be recorded as a property of the text encoded according to these guidelines as part of the teiHeader or in a description of a single physical document (<gi>msDesc</gi>) with the element <gi>authenticationStmt</gi>.</p>
+    <p>The <gi>authenticationStmt</gi> describes material, procedural, symbolic or interpretative authenticity of a document. Any consideration about the relationship between the claim a text makes and reality can be discussed in simple prose.</p>
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="lat" valid="false" xml:id="HD25-egXML-ramble2028" source="#Ramble2018">
+      <authenticationStmt xmlns="">
+        <p>The expansion of the use of the thumbprints as signatures on legal
+          documents in Mustang is likely to be related to the development of the
+          practice in Nepalese legal usage. A spectacular example of a handprint
+          being used in an official administrative context is to be seen in plate 3,
+          a Nepalese government order, dated 1846 and bearing the handprint of
+          King Rajendra Vikram Shah.<note>Edition of the document: Rājendra Vikrama Śāha. 1846 (VS 1903). A pañjāpatra requesting Cautarīyā Bhīma Vikrama Śāha etc. to return to Kathmandu, herausg./übers. von Rajan Khatiwoda mit Simon Cubelic und Christof Zotter. Heidelberg: HAdW (Documenta Nepalica), 2017 : <ptr target="https://digi.hadw-bw.de/view/dna_0016_0086"/></note> In the sense that the print ‘empowers’ the
+          document with royal authority, the function is not too far removed from
+          the explicitly religious connotations of the endorsement of thangkas by
+          lamas mentioned above.</p>
+      </authenticationStmt>
+    </egXML>
+    <p>This chapter suggests further elements dedicated to the core information needed to describe the creation of social reality through the text: 
+      <list>
+        <item>the method of authentication itself (<gi>authDesc</gi>),</item> 
+        <item>the social actors committed to claim of the document (<gi>legalActor</gi>) and</item>
+        <item>The temporal and geographical allocation of the performative utterance of the text (<gi>issued</gi>).</item>
+      </list></p>
+    <div xml:id="HD251">
+      <head>Method of authentication itself (<gi>authDesc</gi>)</head>
+      <p>A generic <gi>auth</gi> element covers all sorts of authentication methods that can be specified through the <att>type</att>-attribute. For some established methods exist elements used in other contexts: Impressions of a <gi>seal</gi> as material object embodying the authority of the issuer, or a <gi>stamp</gi> in ink or embossed mark serving as bureaucratic authentication can serve as symbolic record of authenticity. They express the commitment of the author of a document to its content in the same way as signatures (<gi>signed</gi>) or autographs do through handwriting. Using fingerprints or individualised symbolic drawings like in the medieval notarial culture add other methods that are linked to an individual.</p>
+      <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="lat">
+        <!-- ToDo: eine besiegelte Notarsurkunde aus MOM? -->
+        <authDesc xmlns="">
+          <signed>###TODO###</signed>
+          <seal>###TODO###</seal>
+        </authDesc>
+      </egXML>
+      <p>Technical methods of marking authenticity can be a <gi>watermark</gi>, as a more or less hidden sign embedded in the writing material or a digital file. In the digital realm all sorts digital certificate exist as cryptographic equivalent of a seal or signature in the digital sphere. Algorithmic authentication, e.g. through a blockchain ledger are a technical infrastructure acting as validators in the digital domain. For this purpose, the description of the authentication can also include non-TEI description of authentication like <ref target="https://www.w3.org/TR/xmldsig-core">W3C recommendation how to use XML for digital signatures</ref>.</p>
+      <p>The <att>type</att> of the <gi>auth</gi> element should preferably reference controlled vocabularies, like the <title ref="https://www.cei.lmu.de/VID">Vocabulaire Internationale de la Diplomatique</title>.</p>
+      <p>The element includes the possibility to describe the method of authentication in prose in the reflection of the role of ritual performances creating the social object inscribed in a document. Handing over the document, public reading of a document, courtroom verdicts or oaths can be part of the authentication and need verbal description to record them.</p>
+      <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="lat">
+        <authDesc xmlns=""><p>###TODO###</p></authDesc>
+      </egXML>
+    </div>
+    <div xml:id="HD252">
+      <head>Social actors committed to claim of the document (<gi>legalActor</gi>)</head>
+      <p>Several persons, groups, and institutions can issue the authority of the document. Grantors, donors, sovereigns, magistrate, or in general the <term>issuer</term>of a document are authors of the perforamtive text. They produces the document and claims authority behind it, give a privilege or property, or are the  political or legal authorities whose will the document embodies. Chanceries, i.e. specialized office in royal or ecclesiastical administrations responsible for drafting and issuing charters and diplomas, notaries as legally empowered scribe or official who writes and validates documents in civic and ecclesiastical contexts or the individual scribe physically writing the text, often trained in distinctive scripts signaling authenticity guarantee procedural authenticity.</p>
+      <p>Legal actors can be mediating: Witnesses attest to the truth and legality of the act. Counter-signer add a second signature to strengthen trust in the first. Seal bearer charged with affixing and safeguarding the seal, which authenticates the document, the bureaucrats keeping official registers, against which copies can be checked, custodians and archivist are responsible for preserving and controlling access to the document.</p>
+      <p>In more contemporary environments, specialised registrars of vital statistics certify births, deaths, or marriages. The insitutions of a notary public ensures the authenticity of signatures and transactions. Auditors check the correctness of documents within bureaucratic or financial systems. In digital environments Certification Authorities issue digital certificates that are used to signed documents.</p>
+      <p>On the side of recipients and users, beneficiaries and grantees are legal actors involved as they receive rights or recognition through the document. A petitioner requests a document or privilege and profits from them. Documents become social reality through an the formal audience named in the document that can be the general public, that, as a community can acknowledge the document’s authority (e.g., through ceremonial reading).</p>
+      <p>These roles can be assigned through the <att>type</att> attribute of the <gi>legalActor</gi> element and identified through the naming mechanisms provided by these guidelines. It is recommended to use shared vocabularies for these role, e.g. through the <title ref="https://www.cei.lmu.de/VID">Vocabulare Internationale de la Diplomatique</title>.</p>
+      <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="lat" source="#MonTibetHistIII.8">
+        <legalActor type="https://www.cei.lmu.de/VID/#16" xmlns=""><persName xml:lang="Hant">元順<rolename>帝</rolename></persName>
+          <persName xml:lang="en"><roleName>Emperor</roleName> Toyon Temür</persName></legalActor>
+      </egXML>
+    </div>
+    <div xml:id="HD253">
+      <head>The temporal and geographical allocation of the performative utterance of the text (<gi>issued</gi>)</head>
+      <p>Time and place of the preformative act can describe jurisdiction and gives starting points to the claim of the text. </p>
+      <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="lat">
+        <issued xmlns="">
+          <placeName>###TODO###</placeName>
+          <date>###TODO###</date>
+        </issued>
+      </egXML>
+      
+      <specGrp xml:id="HD254" n="xxx">
+        <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/auth.xml"/><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/authDesc.xml"/>
+        <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/authenticationStmt.xml"/><include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/issued.xml"/>
+        <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/legalActor.xml"/>
+        <include xmlns="http://www.w3.org/2001/XInclude" href="../../Specs/model.authDescPart.xml"/>
+      </specGrp>
+      
+      
+    </div>
+    
+   
+    
+  </div>
 
 <div type="div3" xml:id="HD26"><head>The Series Statement</head>
 <p>The <gi>seriesStmt</gi> element is the fifth component of the

--- a/P5/Source/Specs/auth.xml
+++ b/P5/Source/Specs/auth.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CC-BY licensed -->
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="header" xml:id="gi-auth" ident="auth">
+    <desc versionDate="2025-09-13" xml:lang="en">Any kind of authentication method.</desc>
+    <classes>
+      <memberOf key="att.global"/>
+      <memberOf key="att.typed"/>
+      <memberOf key="model.authDescPart"/>
+    </classes>
+    <content>
+      <alternate minOccurs="1" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.pLike"/>
+      </alternate>
+    </content>
+  <exemplum xml:lang="en" >
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-auth-egXML-vp"  xml:lang="en" valid="false">
+      <authenticationStmt xmlns="">
+        <authDesc>
+          <auth><p>md5 hash</p></auth>
+        </authDesc>
+      </authenticationStmt>
+    </egXML>
+  </exemplum>
+  <remarks xml:lang="en" versionDate="2025-09-13"><p>Several elements in the TEI can have the function of a means of authentication, like a <gi>seal</gi>, a signature (<gi>signed</gi>) or a <gi>stamp</gi>. The <gi>auth</gi> element is considered an generalisation of these elements for authentication practices not covered with dedicated elements.</p>
+    <p>It is recommended to specify this in the <att>type</att> attribute referencing a controlled vocabulary such as the <title ref="https://www.cei.lmu.de/VID">Vocabulaire Internationale de la Diplomatique</title>.</p></remarks>
+  <listRef>
+    <ptr target="#HD25"/>
+  </listRef>
+</elementSpec>

--- a/P5/Source/Specs/authDesc.xml
+++ b/P5/Source/Specs/authDesc.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CC-BY licensed -->
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="header" xml:id="gi-authDesc" ident="authDesc">
+  <gloss versionDate="2025-09-17" xml:lang="en">description of authentication method</gloss>
+  <desc versionDate="2025-09-13" xml:lang="en">The element escribes the method by which the document is validates / authenticated.</desc>
+  <classes>
+    <memberOf key="att.global"/>
+  </classes>
+  <content>
+    <alternate>
+      <classRef key="model.authDescPart"
+        minOccurs="0" maxOccurs="unbounded"/>
+      <classRef key="model.pLike" minOccurs="1"
+        maxOccurs="unbounded"/>
+    </alternate>
+  </content>
+  <exemplum xml:lang="en" >
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-authDesc-egXML-vp"  xml:lang="en" source="#AbdictionPuyi" valid="false">
+      <fileDesc>
+        <titleStmt>
+          <title>Edict of the Abdication by Puyi</title>
+        </titleStmt>
+        <publicationStmt>
+          <p>...</p>
+        </publicationStmt>
+        <authenticationStmt xmlns="">
+          <authDesc>
+            <sealDesc><p>Validated by the seal of the Emperor</p></sealDesc>
+          </authDesc>
+          <legalActor><persName ref="https://d-nb.info/gnd/118819097">The Emperor Qing Xuantongì</persName></legalActor>
+          <issued when="1912-02-12">宣统三年正月二十五日</issued>
+        </authenticationStmt>
+      </fileDesc>
+    </egXML>
+  </exemplum>
+  <listRef>
+    <ptr target="#HD25"/>
+  </listRef>
+</elementSpec>

--- a/P5/Source/Specs/authenticationStmt.xml
+++ b/P5/Source/Specs/authenticationStmt.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CC-BY licensed -->
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="header" xml:id="gi-authenticationStmt" ident="authenticationStmt">
+  <gloss versionDate="2025-09-17" xml:lang="en">statement of authentication</gloss>
+  <desc versionDate="2011-11-16" xml:lang="en">describes the features of the text that makes it a document creating social reality through a formalized act of inscription.</desc>
+  <classes>
+    <memberOf key="att.global"/>
+    <memberOf key="att.canonical"/>
+  </classes>
+  <content>
+    <sequence maxOccurs="1" minOccurs="1">
+      <elementRef key="authDesc"/>
+      <elementRef key="legalActor"/>
+      <elementRef key="issued"/>
+    </sequence>
+  </content>
+  <exemplum xml:lang="en" >
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-authenticationStmt-egXML-vp"  xml:lang="en" valid="false">
+      <fileDesc>
+        <titleStmt>
+          <title>A strong document</title>
+        </titleStmt>
+        <publicationStmt>
+          <p>Distributed as part of TEI P5</p>
+        </publicationStmt>
+        <authenticationStmt xmlns="">
+          <authDesc>
+            <sealDesc><p>Validated by the seal of the Emperor</p></sealDesc>
+          </authDesc>
+          <legalActor><persName ref="https://d-nb.info/gnd/118819097">The <roleName>Emperor</roleName> Qing Xuantongì</persName></legalActor>
+          <issued when="1912-02-12">宣统三年正月二十五日</issued>
+        </authenticationStmt>
+      </fileDesc>
+    </egXML>
+  </exemplum>
+  <listRef>
+    <ptr target="#HD25"/>
+    <ptr target="#MS"/>
+  </listRef>
+</elementSpec>

--- a/P5/Source/Specs/fileDesc.xml
+++ b/P5/Source/Specs/fileDesc.xml
@@ -39,6 +39,8 @@
         
           <elementRef key="notesStmt" minOccurs="0"/>
         
+          <elementRef key="authenticationStmt" minOccurs="0"/>
+        
       </sequence>
       
         <elementRef key="sourceDesc" minOccurs="1" maxOccurs="unbounded"/>

--- a/P5/Source/Specs/issued.xml
+++ b/P5/Source/Specs/issued.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CC-BY licensed -->
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="header" xml:id="gi-issued" ident="issued">
+  <gloss versionDate="2025-09-17" xml:lang="en">date of issuing</gloss>
+  <desc versionDate="2025-09-13" xml:lang="en">Date on which a document was made official, and by this the social reality describe in it becomes existent.</desc>
+  <classes>
+    <memberOf key="att.global"/>
+    <memberOf key="att.calendarSystem"/>
+    <memberOf key="att.datable"/>
+    <memberOf key="att.typed"/>
+    <memberOf key="model.dateLike"/>
+    <memberOf key="model.publicationStmtPart.detail"/>
+  </classes>
+  <content>
+    <alternate minOccurs="1" maxOccurs="unbounded">
+      <textNode/>
+      <classRef key="model.pLike"/>
+      <classRef key="model.dateLike"/>
+      <classRef key="model.placeLike"/>
+      <!--<textNode/>-->
+    </alternate>
+  </content>
+  <exemplum xml:lang="en" >
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:id="gi-issued-egXML-vs"  xml:lang="en" valid="false">
+      <authenticationStmt xmlns="">
+        <authDesc>
+          <sealDesc><p>Validated by the seal of the Emperor</p></sealDesc>
+        </authDesc>
+        <legalActor><persName ref="https://d-nb.info/gnd/118819097">The Emperor Qing Xuantongì</persName></legalActor>
+        <issued when="1912-02-12">宣统三年正月二十五日</issued>
+      </authenticationStmt>
+    </egXML>
+  </exemplum>
+  <listRef>
+    <ptr target="#HD25"/>
+  </listRef>
+</elementSpec>

--- a/P5/Source/Specs/legalActor.xml
+++ b/P5/Source/Specs/legalActor.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CC-BY licensed -->
+<?xml-model href="https://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<elementSpec xmlns="http://www.tei-c.org/ns/1.0" module="header" xml:id="gi-legalActor" ident="legalActor">
+  <gloss versionDate="2025-09-17" xml:lang="en">legal actor</gloss>
+  <desc versionDate="2025-09-13" xml:lang="en">Legal actors are those persons and institutions that are committed to the social reality created by a documnet. This can be notaries validating a text, legal parties of the act described in the text, witnesses to the legal act etc.</desc>
+  <classes>
+    <memberOf key="att.global"/>
+  </classes>
+  <content>
+    <alternate minOccurs="1" maxOccurs="unbounded">
+      <textNode/>
+      <classRef key="model.pLike"/>
+      <classRef key="model.nameLike.agent"/>
+      <classRef key="model.publicationStmtPart.agency"/>
+      <!--<textNode/>-->
+    </alternate>
+  </content>
+  <exemplum xml:lang="en" >
+    <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:lang="lat" xml:id="gi-legalActor-egXML-tt" source="#MonTibetHistIII.8">
+      <authenticationStmt xmlns="">
+          <legalActor type="https://www.cei.lmu.de/VID/#16" xmlns=""><persName xml:lang="Hant">元順<rolename>帝</rolename></persName>
+            <persName xml:lang="en"><roleName>Emperor</roleName> Toyon Temür</persName></legalActor>
+      </authenticationStmt>
+    </egXML>
+  </exemplum>
+  <remarks xml:lang="en" versionDate="2025-09-17"><p>These roles can be assigned through the <att>type</att> attribute of the <gi>legalActor</gi> element and identified through the naming mechanisms provided by these guidelines. It is recommended to use shared vocabularies for these role, e.g. through the <title ref="https://www.cei.lmu.de/VID">Vocabulare Internationale de la Diplomatique</title>.</p></remarks>
+
+  <listRef>
+    <ptr target="#HD25"/>
+  </listRef>
+</elementSpec>

--- a/P5/Source/Specs/post.xml
+++ b/P5/Source/Specs/post.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright TEI Consortium.
-Dual-licensed under CC-by and BSD2 licences
-See the file COPYING.txt for details.
--->
+<!-- © TEI Consortium. Dual-licensed under CC-by and BSD2 licenses; see the file COPYING.txt for details. -->
 <?xml-model href="http://jenkins.tei-c.org/job/TEIP5-dev/lastSuccessfulBuild/artifact/P5/release/xml/tei/odd/p5.nvdl" type="application/xml" schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
 <elementSpec xmlns="http://www.tei-c.org/ns/1.0" ident="post" mode="add" xml:id="gi-post" module="cmc">
   <desc versionDate="2022-08-09" xml:lang="en">a written (or spoken) contribution to a CMC interaction which has been composed (or recorded) by its author in its entirety before being transmitted over a network (e.g., the internet) and made available on the monitor or screen of the other parties en bloc.</desc>
@@ -32,7 +28,14 @@ See the file COPYING.txt for details.
       <classRef key="model.global"/>
       <elementRef key="lg"/>
       <classRef key="model.lLike"/>
-      <classRef key="model.divBottom"/>
+      <!-- These are the components of model.divBottom, but without
+	   <address>, which is already available via model.phrase: -->
+      <elementRef key="closer"/>
+      <elementRef key="postscript"/>
+      <elementRef key="signed"/>
+      <elementRef key="trailer"/>
+      <classRef key="model.divWrapper"/>
+      <!-- end of model.divBottom without <address> -->
     </alternate>
   </content>
   <attList>
@@ -61,15 +64,15 @@ See the file COPYING.txt for details.
         <dataRef key="teidata.pointer"/>
       </datatype>
       <remarks versionDate="2024-07-07" xml:lang="en">
-	<p>This attribute should be used to encode <q>technical</q>
-	reply information that is due to a formal reply action (such
-	as activating a <q>reply</q> button in the client software)
-	and that is formally represented in the source, e.g. in the
-	<q>references</q> field of a Usenet message header or in the
-	subject line of a forum post. It should not be used for
-	inferred or interpreted reply relations based only on
-	ambiguous signs such as linguistic discourse markers or
-	indentation.</p>
+        <p>This attribute should be used to encode <q>technical</q>
+        reply information that is due to a formal reply action (such
+        as activating a <q>reply</q> button in the client software)
+        and that is formally represented in the source, e.g. in the
+        <q>references</q> field of a Usenet message header or in the
+        subject line of a forum post. It should not be used for
+        inferred or interpreted reply relations based only on
+        ambiguous signs such as linguistic discourse markers or
+        indentation.</p>
         <!--See Lüngen/Herzberg (2019)-->
       </remarks>
     </attDef>
@@ -188,10 +191,10 @@ See the file COPYING.txt for details.
       <post when="1990-10-11" who="#dmerritt" xml:id="sgml-tei-3" replyTo="#sgml-tei-1">
         <time generatedBy="system">04:37:51 UTC</time>
         <p>
-	  <seg generatedBy="system">In article
-	  <ref target="#sgml-tei-1">&lt;2****.**********0@m*******.***.*****.**c.uk&gt;</ref> S.*.*.*****z@e**.*****.**c.uk (Sebastian Rahtz) writes:</seg>
+          <seg generatedBy="system">In article
+          <ref target="#sgml-tei-1">&lt;2****.**********0@m*******.***.*****.**c.uk&gt;</ref> S.*.*.*****z@e**.*****.**c.uk (Sebastian Rahtz) writes:</seg>
           <cit>
-	    <bibl>[for] Lou Burnard:</bibl>
+            <bibl>[for] Lou Burnard:</bibl>
             <quote>the Text Encoding Initiative document is a many-splendoured thing,
             redolent of the mysterious east, caribbean evenings and the scent of
             fresh pine in the himalayas [...]</quote>
@@ -201,8 +204,8 @@ See the file COPYING.txt for details.
         <p>But really, what is it?</p>  
         <signed generatedBy="human">Doug</signed>
         <signed generatedBy="template">
-	  Doug Merritt ****@e***.********y.edu (ucbvax!eris!doug) or uunet.uu.net!crossck!dougm
-	</signed>
+          Doug Merritt ****@e***.********y.edu (ucbvax!eris!doug) or uunet.uu.net!crossck!dougm
+        </signed>
       </post>
     </egXML>
   </exemplum>

--- a/P5/Test/Makefile
+++ b/P5/Test/Makefile
@@ -41,7 +41,7 @@ checkrnv:
 
 testall.examples: testall.xsd
 	@echo " "
-	@echo "--------- work on target $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target $@ ---------"
 	$(SAXON) -o:testall-ex.odd -s:testall.odd -xsl:../Utilities/odd2exodd.xsl
 	$(ANT) -f antruntest.xml -Doutputname=testall-examples -DoddFile=testall-ex.odd compileodd rng cleanup
 	@echo check egXML in testall.odd
@@ -50,14 +50,14 @@ testall.examples: testall.xsd
 
 %.dtd: %.odd
 	@echo " "
-	@echo "--------- work on target file $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target file $@ ---------"
 	$(ANT) -f antruntest.xml -Doutputname=$* -Dtestfile=$*.xml -DoddFile=$*.odd validateodd compileodd dtd rng validaterng cleanup
 	@echo Check file using DOCTYPE in instance
 	xmllint --noout --valid $*.xml
 
 %.xsd: %.odd
 	@echo " "
-	@echo "--------- work on target file $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target file $@ ---------"
 	$(ANT) -f antruntest.xml -Doutputname=$* -Dtestfile=$*.xml -DoddFile=$*.odd validateodd compileodd rng validaterng  isoschematron validateschematron cleanup
 	${TRANG}   -o disable-abstract-elements $*.rng $*.xsd
 	-test -f xml.xsd && cp xml.xsd $*_xml.xsd    && perl -p -i -e "s+xml.xsd+$*_xml.xsd+;s+ns1.xsd+$*_ns1.xsd+;s+teix.xsd+$*_teix.xsd+" $*.xsd
@@ -69,7 +69,7 @@ testall.examples: testall.xsd
 
 %.special: %.odd checkrnv
 	@echo " "
-	@echo "--------- work on target file $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target file $@ ---------"
 	@echo "BUILD:  Test schema from (special) $<"
 	xmllint --xinclude $< > xi_$<
 	$(ANT) -f antruntest.xml -Dtestfile=$*.xml -DoddFile=xi_$*.odd -Doutputname=$* validateodd compileodd rng validaterng cleanup
@@ -79,7 +79,7 @@ testall.examples: testall.xsd
 
 testmeta2010:
 	@echo " "
-	@echo "--------- work on target $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target $@ ---------"
 	@echo check that TEI web site is up and responding ...
 	-TEISITE=`curl -s --head http://www.tei-c.org/Vault/P5/1.5.0/xml/tei/odd/p5subset.xml`
 ifdef TEISITE
@@ -97,14 +97,14 @@ endif
 
 test-frag: checkrnv
 	@echo " "
-	@echo "--------- work on target $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target $@ ---------"
 	@echo BUILD: Testing files which exercise inclusion of fragments
 	${JING} -t -c frag.rnc testfrag.xml
 	rnv frag.rnc testfrag.xml
 
 detest: checkrnv
 	@echo " "
-	@echo "--------- work on target $@ ---------"
+	@echo "--------- P5/Test/Makefile work on target $@ ---------"
 	@echo BUILD: Test file with deliberate mistakes
 	@echo "--- run ant to validate ODD file (./detest.odd) against p5odds.rng & p5odds.isosch:"
 	$(ANT) -f antruntest.xml -Doutputname=detest -DoddFile=detest.odd validateodd > detest_odd_schematron.log 2>&1


### PR DESCRIPTION
Files in Testumgebung getestet: Schema (tei_all.rng) und Website werden generiert. 

**auth.xml**
- `@ident` und `@xml:id` in `<elementSpec>` von authen auf auth geändert; 
- `@source` entfernt, ergibt einen Validierungsfehler; 
- in `<remarks>` authen auf auth geändert; Reihenfolge beim `<content>` geändert, 
- `<textNode/>` muss zuerst kommen, sonst gibt es einen DTD Fehler. 

**authenDesc.xml**
- `@xml:id` und @ident in `<elementSpec>` von authenDesc auf authDesc geändert

**authenticationStmt.xml**
- `@source` aus `<egXML>` entfernt

**issued.xml**
- `<textNode>` im `<content>` an den Beginn gestellt
- `@source` im `<egXML>` entfernt

**legalActor.xml**
-`<textNode>` im `<content>` an den Beginn gestellt

**model.authDescPart.xml**
- `xml:id` entfernt

**fileDesc.xml**
- `<elementRef key="authenticationStmt" minOccurs="0"/>` hinzugefügt. Hier musst du noch entscheiden, wo es tatsächlich vorkommen kann. 

**HD-Header.xml**
- Die meisten `<specDesc>` auf `<gi>` geändert. Wenn du eine `<specDesc>` verwenden willst, dann muss diese innerhalb einer `<specList>` stehen, auch wenn es nur eine `<specDesc>` gibt. 
- `<specGrp>` am Ende des Abschnitts notwendig mit `<include>`, damit Spec auch tatsächlich eingehängt wird. 
- `@source` in `<egXML>` entfernt. Offenes ToDo. 
- Zu Beginn des Kapitels sollte bei der Intro noch das `<authenticationStmt>` erwähnt werden. 
- Beim Absatz "This chapter suggests further elements ... " würde sich anbieten, dass du eine `specList/specDesc` machst. Allderings musst du dann den Text entfernen, weil die Beschreibung dann direkt aus der jeweiligen Spec ausgelesen wird. 
